### PR TITLE
Convert Dockerfile to multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,25 @@
-FROM alpine:latest
+FROM golang:1.10-alpine as build
 
-ADD internallb-webhook-admission-controller /internallb-webhook-admission-controller
-CMD ["/internallb-webhook-admission-controller","--alsologtostderr","-v=4","2>&1"]
+RUN apk --update add gcc libc-dev
+
+ADD . /go/src/github.com/lachie83/internallb-webhook-admission-controller
+
+WORKDIR /go/src/github.com/lachie83/internallb-webhook-admission-controller
+
+RUN go build -buildmode=pie -ldflags "-linkmode external -extldflags -static -w" -o internallb-webhook-admission-controller
+
+# The RUN line below is an alternative that also results in a static binary
+# that can be run FROM scratch but results in a slightly-larger executable
+# without ASLR.
+#
+# RUN CGO_ENABLED=0 go build -a -o internallb-webhook-admission-controller
+
+FROM scratch
+
+USER 1
+
+EXPOSE 8443
+
+COPY --from=build /go/src/github.com/lachie83/internallb-webhook-admission-controller/internallb-webhook-admission-controller /
+
+CMD ["/internallb-webhook-admission-controller","--logtostderr","-v=4","2>&1"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
 build:
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o internallb-webhook-admission-controller .
 	docker build -t internallb-webhook-admission-controller .
 


### PR DESCRIPTION
This is now a 2-stage `Dockerfile`; the first stage builds the webhook static binary with [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization) protection and the second stage builds a `FROM scratch` image.
